### PR TITLE
Fix High GPU usage when layer is idling 

### DIFF
--- a/src/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
+++ b/src/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
@@ -1,4 +1,4 @@
-﻿using Artemis.Core;
+using Artemis.Core;
 using Artemis.Core.LayerBrushes;
 using Artemis.Plugins.LayerBrushes.Ambilight.PropertyGroups;
 using SkiaSharp;
@@ -139,8 +139,8 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight
                 var renderBounds = Layer.Bounds;
                 var widthScale = pixmap.Width / renderBounds.Width;
                 var heightScale = pixmap.Height / renderBounds.Height;
-                int x = (int)(renderPoint.X * widthScale);
-                int y = (int)(renderPoint.Y * heightScale);
+                int x = (int)Math.Max((renderPoint.X * widthScale), 0);
+                int y = (int)Math.Max((renderPoint.Y * heightScale), 0);
                 int width = (int)(led.Rectangle.Width * widthScale);
                 int height = (int)(led.Rectangle.Height * heightScale);
 

--- a/src/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
+++ b/src/Artemis.Plugins.LayerBrushes.Ambilight/AmbilightLayerBrush.cs
@@ -154,7 +154,10 @@ namespace Artemis.Plugins.LayerBrushes.Ambilight
                     {
                         var bruhX = x + horizontalSteps * horizontalStep;
                         var bruhY = y + verticalSteps * verticalStep;
-                        SKColor color = pixmap.GetPixelColor(bruhX, bruhY);
+                        SKColor color = pixmap.GetPixelColor(
+                            Math.Min(bruhX, pixmap.Width - 1),
+                            Math.Min(bruhY, pixmap.Height - 1)
+                            );
                         r += color.Red;
                         g += color.Green;
                         b += color.Blue;


### PR DESCRIPTION
Duplicator keep semi high GPU usage when a frame is not released.

Added a timer to release the last generated frame after 5 frames of inactivity. This workarround fixes GPU usage at the same time the layer keeps the "release frame just before capture" logic.

