### PR TITLE
Updated Artemis reference paths and launch settings

### DIFF
--- a/src/Artemis.Plugins.DataModelExpansions.Aida64/Artemis.Plugins.DataModelExpansions.Aida64.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.Aida64/Artemis.Plugins.DataModelExpansions.Aida64.csproj
@@ -31,11 +31,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.Aida64/Artemis.Plugins.DataModelExpansions.Aida64.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.Aida64/Artemis.Plugins.DataModelExpansions.Aida64.csproj
@@ -22,14 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
-    </Page>
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="Artemis.Core">
       <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>

--- a/src/Artemis.Plugins.DataModelExpansions.Aida64/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.Aida64/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ModuleProject": {
       "commandName": "Executable",
       "executablePath": ".\\Artemis.UI.exe",
-      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.DataModelExpansions.Discord/Artemis.Plugins.DataModelExpansions.Discord.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.Discord/Artemis.Plugins.DataModelExpansions.Discord.csproj
@@ -25,11 +25,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.Discord/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.Discord/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ModuleProject": {
       "commandName": "Executable",
       "executablePath": ".\\Artemis.UI.exe",
-      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.DataModelExpansions.HardwareMonitor/Artemis.Plugins.DataModelExpansions.HardwareMonitor.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.HardwareMonitor/Artemis.Plugins.DataModelExpansions.HardwareMonitor.csproj
@@ -23,11 +23,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.HardwareMonitor/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.HardwareMonitor/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.DataModelExpansions.OBS/Artemis.Plugins.DataModelExpansions.OBS.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.OBS/Artemis.Plugins.DataModelExpansions.OBS.csproj
@@ -22,11 +22,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.OBS/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.OBS/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.DataModelExpansions.Spotify/Artemis.Plugins.DataModelExpansions.Spotify.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.Spotify/Artemis.Plugins.DataModelExpansions.Spotify.csproj
@@ -26,11 +26,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.Spotify/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.Spotify/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor.csproj
+++ b/src/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor.csproj
@@ -21,11 +21,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.DataModelExpansions.StandaloneHardwareMonitor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ModuleProject": {
       "commandName": "Executable",
       "executablePath": ".\\Artemis.UI.exe",
-      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.LayerBrushes.Ambilight/Artemis.Plugins.LayerBrushes.Ambilight.csproj
+++ b/src/Artemis.Plugins.LayerBrushes.Ambilight/Artemis.Plugins.LayerBrushes.Ambilight.csproj
@@ -22,11 +22,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
 

--- a/src/Artemis.Plugins.LayerBrushes.Ambilight/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.LayerBrushes.Ambilight/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "ModuleProject": {
       "commandName": "Executable",
       "executablePath": ".\\Artemis.UI.exe",
-      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.LayerBrushes.Chroma/Artemis.Plugins.LayerBrushes.Chroma.csproj
+++ b/src/Artemis.Plugins.LayerBrushes.Chroma/Artemis.Plugins.LayerBrushes.Chroma.csproj
@@ -21,11 +21,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="RazerSdkWrapper">

--- a/src/Artemis.Plugins.LayerBrushes.Chroma/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.LayerBrushes.Chroma/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.LayerBrushes.Gif/Artemis.Plugins.LayerBrushes.Gif.csproj
+++ b/src/Artemis.Plugins.LayerBrushes.Gif/Artemis.Plugins.LayerBrushes.Gif.csproj
@@ -24,11 +24,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <!-- TODO: Replace with PackageReferences when moving to Nuget -->

--- a/src/Artemis.Plugins.LayerBrushes.Gif/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.LayerBrushes.Gif/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.LayerBrushes.Particle/Artemis.Plugins.LayerBrushes.Particle.csproj
+++ b/src/Artemis.Plugins.LayerBrushes.Particle/Artemis.Plugins.LayerBrushes.Particle.csproj
@@ -20,11 +20,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <!-- TODO: Replace with PackageReferences when moving to Nuget -->

--- a/src/Artemis.Plugins.LayerBrushes.Particle/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.LayerBrushes.Particle/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "ModuleProject": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.Modules.Fallout4/Artemis.Plugins.Modules.Fallout4.csproj
+++ b/src/Artemis.Plugins.Modules.Fallout4/Artemis.Plugins.Modules.Fallout4.csproj
@@ -19,11 +19,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.Modules.Fallout4/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.Modules.Fallout4/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "ModuleProject": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows\\Artemis.UI.exe",
+      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }

--- a/src/Artemis.Plugins.Modules.LeagueOfLegends/Artemis.Plugins.Modules.LeagueOfLegends.csproj
+++ b/src/Artemis.Plugins.Modules.LeagueOfLegends/Artemis.Plugins.Modules.LeagueOfLegends.csproj
@@ -24,11 +24,11 @@
 
   <ItemGroup>
     <Reference Include="Artemis.Core">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.Core.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.Core.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Artemis.UI.Shared">
-      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\x64\Debug\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
+      <HintPath>..\..\..\Artemis\src\Artemis.UI\bin\net5.0-windows\Artemis.UI.Shared.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/src/Artemis.Plugins.Modules.LeagueOfLegends/Properties/launchSettings.json
+++ b/src/Artemis.Plugins.Modules.LeagueOfLegends/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Launch Artemis": {
       "commandName": "Executable",
-      "executablePath": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows\\Artemis.UI.exe",
-      "workingDirectory": "D:\\Source\\Artemis\\Artemis\\src\\Artemis.UI\\bin\\x64\\Debug\\net5.0-windows"
+      "executablePath": ".\\Artemis.UI.exe",
+      "workingDirectory": "..\\..\\..\\Artemis\\src\\Artemis.UI\\bin\\net5.0-windows"
     }
   }
 }


### PR DESCRIPTION
I changed the build path of Artemis to no longer include configuration and CPU type, this PR fixes the references of plugin projects to match the new paths.